### PR TITLE
Fix normalizeMenuHeader function

### DIFF
--- a/src/create-menu/createMenu.js
+++ b/src/create-menu/createMenu.js
@@ -490,14 +490,18 @@ function normalizeMenuText(props) {
 }
 
 function normalizeMenuHeader(props) {
-    let { menuFields, userLanguage } = props;
+    let { menuFields, userLanguage, userChannel } = props;
     let headerText;
-    if (menuFields.header && menuFields.header[userLanguage]) {
+    if (menuFields.header && typeof menuFields.header === 'string') {
+        headerText = menuFields.header;
+    } else if (menuFields.header && menuFields.header[userLanguage] && typeof menuFields.header[userLanguage] === 'string') {
         headerText = menuFields.header[userLanguage];
-    } else if (typeof menuFields.header === 'string') {
+    } else if (menuFields.header && menuFields.header[userLanguage] && userChannel === 'whatsapp') {
+        headerText = menuFields.header[userLanguage];
+    } else if (menuFields.header && userChannel === 'whatsapp'){
         headerText = menuFields.header;
     } else {
-        headerText = null;
+        return;
     }
     return headerText;
 }


### PR DESCRIPTION
Fixed normalizeMenuHeader function. The header must support media on whatsapp but not on other platforms. As it was, if the generated menu used media on whatsapp, a bug would appear on other platforms.

Example:
![image](https://user-images.githubusercontent.com/58819530/142771005-f2c6cff1-6413-4ae8-8e6e-7fa9c0e9cb51.png)

The correction consists of keeping header on other platforms only if it is a string. Otherwise the menu is generated without a header.